### PR TITLE
Add Telegram game session management and filtered commands

### DIFF
--- a/src/main/java/ru/sensual/sense_game/model/GameSession.java
+++ b/src/main/java/ru/sensual/sense_game/model/GameSession.java
@@ -1,0 +1,59 @@
+package ru.sensual.sense_game.model;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Содержит состояние игровой сессии в конкретном чате Telegram.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+public class GameSession {
+
+    private Long chatId;
+    private boolean active;
+    private Set<String> categories = new HashSet<>();
+    private Integer minDifficulty;
+    private Integer maxDifficulty;
+    private Card currentCard;
+    private Long currentPlayerId;
+    private String currentPlayerName;
+
+    public GameSession(Long chatId) {
+        this.chatId = chatId;
+    }
+
+    public String describeSettings() {
+        var builder = new StringBuilder();
+        builder.append("Категории: ");
+        if (categories == null || categories.isEmpty()) {
+            builder.append("все");
+        } else {
+            builder.append(String.join(", ", categories));
+        }
+
+        builder.append("\nСложность: ");
+        if (minDifficulty == null && maxDifficulty == null) {
+            builder.append("любая");
+        } else if (minDifficulty != null && maxDifficulty != null && minDifficulty.equals(maxDifficulty)) {
+            builder.append(minDifficulty);
+        } else {
+            if (minDifficulty != null) {
+                builder.append("от ").append(minDifficulty);
+            }
+            if (maxDifficulty != null) {
+                if (minDifficulty != null) {
+                    builder.append(" ");
+                }
+                builder.append("до ").append(maxDifficulty);
+            }
+        }
+        return builder.toString();
+    }
+}
+

--- a/src/main/java/ru/sensual/sense_game/service/CardService.java
+++ b/src/main/java/ru/sensual/sense_game/service/CardService.java
@@ -18,9 +18,12 @@ import ru.sensual.sense_game.model.type.UploadMessageType;
 import ru.sensual.sense_game.repository.CardRepository;
 
 import java.io.InputStream;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 import static ru.sensual.sense_game.model.type.UploadMessageType.FAILED;
 import static ru.sensual.sense_game.model.type.UploadMessageType.LOADED_WITH_FAILS;
@@ -52,12 +55,44 @@ public class CardService {
      * @return случайная {@link Card}, если доступна; в противном случае, карточка с placeholder-значениями.
      */
     public Card getRandomCard() {
+        return getRandomCard(new HashSet<>(), null, null, null);
+    }
+
+    /**
+     * Получает случайную карточку из репозитория с учётом фильтрации по категории и уровню сложности.
+     * Если карточки отсутствуют, возвращает карточку с дефолтными значениями.
+     *
+     * @param categories   список допустимых категорий. Если пустой, категории не фильтруются.
+     * @param minDifficulty минимально допустимый уровень сложности. {@code null}, если ограничение отсутствует.
+     * @param maxDifficulty максимально допустимый уровень сложности. {@code null}, если ограничение отсутствует.
+     * @param previousCard  предыдущая карточка для исключения повторов. {@code null}, если исключение не требуется.
+     * @return случайная {@link Card}, подходящая под условия фильтра, либо карточка с placeholder-значениями,
+     * если ничего не найдено.
+     */
+    public Card getRandomCard(Set<String> categories, Integer minDifficulty, Integer maxDifficulty, Card previousCard) {
         var cards = cardRepository.findAll();
         if (CollectionUtils.isEmpty(cards)) {
             log.warn("Table with cards in database is empty. Nothing to return");
             return new Card(-1L, "Нет доступных карточек.", "NONE", -1);
         }
-        var card = cards.get(random.nextInt(cards.size()));
+
+        var normalizedCategories = normalizeCategories(categories);
+        var filteredCards = cards.stream()
+                .filter(card -> filterByCategory(card, normalizedCategories))
+                .filter(card -> filterByDifficulty(card, minDifficulty, maxDifficulty))
+                .collect(Collectors.toList());
+
+        if (CollectionUtils.isEmpty(filteredCards)) {
+            log.warn("No cards were found for filters. Categories: {}, minDifficulty: {}, maxDifficulty: {}",
+                    normalizedCategories, minDifficulty, maxDifficulty);
+            return new Card(-1L, "Нет доступных карточек по заданным фильтрам.", "NONE", -1);
+        }
+
+        if (previousCard != null && filteredCards.size() > 1) {
+            filteredCards.removeIf(card -> previousCard.getId() != null && previousCard.getId().equals(card.getId()));
+        }
+
+        var card = filteredCards.get(random.nextInt(filteredCards.size()));
         log.info("Received random card with text: [{}]", card.getText());
         return card;
     }
@@ -189,6 +224,34 @@ public class CardService {
     private UploadMessageType getMessageType(int successCount, int failCount) {
         if (failCount == 0) return SUCCESS;
         return successCount != 0 ? LOADED_WITH_FAILS : FAILED;
+    }
+
+    private boolean filterByCategory(Card card, Set<String> normalizedCategories) {
+        if (CollectionUtils.isEmpty(normalizedCategories)) {
+            return true;
+        }
+        var cardCategory = StringUtils.hasText(card.getCategory()) ? card.getCategory().trim().toLowerCase() : "";
+        return normalizedCategories.contains(cardCategory);
+    }
+
+    private boolean filterByDifficulty(Card card, Integer minDifficulty, Integer maxDifficulty) {
+        if (minDifficulty != null && card.getDifficulty() < minDifficulty) {
+            return false;
+        }
+        if (maxDifficulty != null && card.getDifficulty() > maxDifficulty) {
+            return false;
+        }
+        return true;
+    }
+
+    private Set<String> normalizeCategories(Set<String> categories) {
+        if (CollectionUtils.isEmpty(categories)) {
+            return new HashSet<>();
+        }
+        return categories.stream()
+                .filter(StringUtils::hasText)
+                .map(value -> value.trim().toLowerCase())
+                .collect(Collectors.toSet());
     }
 
 }

--- a/src/main/java/ru/sensual/sense_game/service/GameSessionService.java
+++ b/src/main/java/ru/sensual/sense_game/service/GameSessionService.java
@@ -1,0 +1,78 @@
+package ru.sensual.sense_game.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.util.CollectionUtils;
+import ru.sensual.sense_game.model.Card;
+import ru.sensual.sense_game.model.GameSession;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Service
+public class GameSessionService {
+
+    private final Map<Long, GameSession> sessions = new ConcurrentHashMap<>();
+
+    public GameSession startSession(Long chatId, Set<String> categories, Integer minDifficulty, Integer maxDifficulty) {
+        var session = sessions.computeIfAbsent(chatId, GameSession::new);
+        session.setActive(true);
+        session.setCategories(new HashSet<>(normalizeCategories(categories)));
+        session.setMinDifficulty(minDifficulty);
+        session.setMaxDifficulty(maxDifficulty);
+        session.setCurrentCard(null);
+        session.setCurrentPlayerId(null);
+        session.setCurrentPlayerName(null);
+        return session;
+    }
+
+    public Optional<GameSession> getSession(Long chatId) {
+        return Optional.ofNullable(sessions.get(chatId));
+    }
+
+    public void endSession(Long chatId) {
+        sessions.computeIfPresent(chatId, (id, session) -> {
+            session.setActive(false);
+            session.setCurrentCard(null);
+            session.setCurrentPlayerId(null);
+            session.setCurrentPlayerName(null);
+            return session;
+        });
+    }
+
+    public void updateCurrentTurn(Long chatId, Card card, Long playerId, String playerName) {
+        sessions.computeIfPresent(chatId, (id, session) -> {
+            session.setCurrentCard(card);
+            session.setCurrentPlayerId(playerId);
+            session.setCurrentPlayerName(playerName);
+            return session;
+        });
+    }
+
+    public void updateCurrentCard(Long chatId, Card card) {
+        sessions.computeIfPresent(chatId, (id, session) -> {
+            session.setCurrentCard(card);
+            return session;
+        });
+    }
+
+    public boolean isSessionActive(Long chatId) {
+        return getSession(chatId).map(GameSession::isActive).orElse(false);
+    }
+
+    public Set<String> normalizeCategories(Set<String> categories) {
+        if (CollectionUtils.isEmpty(categories)) {
+            return Collections.emptySet();
+        }
+        var normalized = new HashSet<String>();
+        categories.stream()
+                .filter(value -> value != null && !value.isBlank())
+                .map(value -> value.trim())
+                .forEach(normalized::add);
+        return normalized;
+    }
+}
+

--- a/src/main/java/ru/sensual/sense_game/telegram/SenseGameBot.java
+++ b/src/main/java/ru/sensual/sense_game/telegram/SenseGameBot.java
@@ -8,7 +8,14 @@ import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
 import org.telegram.telegrambots.meta.api.objects.Update;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
 import ru.sensual.sense_game.configuration.TelegramBotConfig;
+import ru.sensual.sense_game.model.GameSession;
 import ru.sensual.sense_game.service.CardService;
+import ru.sensual.sense_game.service.GameSessionService;
+
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Set;
 
 @Slf4j
 @Component
@@ -17,6 +24,7 @@ public class SenseGameBot extends TelegramLongPollingBot {
 
     private final TelegramBotConfig telegramBotConfig;
     private final CardService cardService;
+    private final GameSessionService gameSessionService;
 
     @Override
     public String getBotUsername() {
@@ -31,27 +39,225 @@ public class SenseGameBot extends TelegramLongPollingBot {
     @Override
     public void onUpdateReceived(Update update) {
         if (update.hasMessage() && update.getMessage().hasText()) {
-            var userMessage = update.getMessage().getText();
+            var userMessage = update.getMessage().getText().trim();
             var chatId = update.getMessage().getChatId();
-            if (userMessage.equalsIgnoreCase("/start")) {
-                sendTextMessage(chatId, "Добро пожаловать в Sense Game! Используйте команду /get_card, чтобы получить карточку.");
-            } else if (userMessage.equalsIgnoreCase("/get_card")) {
-                var card = cardService.getRandomCard();
-                sendTextMessage(chatId, "Вот ваша карточка: " + card.getText());
-            } else {
-                sendTextMessage(chatId, "Неизвестная команда. Попробуйте /get_card.");
+            if (!userMessage.startsWith("/")) {
+                return;
+            }
+            var command = extractCommand(userMessage);
+            switch (command) {
+                case "/start" -> handleStartCommand(chatId);
+                case "/help" -> handleHelpCommand(chatId);
+                case "/newgame" -> handleNewGameCommand(chatId, userMessage);
+                case "/nextcard" -> handleNextCardCommand(update, chatId);
+                case "/skipcard" -> handleSkipCardCommand(chatId);
+                case "/stopgame" -> handleStopGameCommand(chatId);
+                default -> sendTextMessage(chatId, "Неизвестная команда. Используйте /help, чтобы посмотреть доступные команды.");
             }
         }
     }
 
     private void sendTextMessage(Long chatId, String text) {
-        var message = new SendMessage();
-        message.setChatId(chatId.toString());
-        message.setText(text);
+        var message = new SendMessage(chatId.toString(), text);
         try {
             execute(message);
         } catch (TelegramApiException e) {
-            System.out.println("Error while trying send text message." + e);
+            log.error("Error while trying send text message", e);
         }
     }
+
+    private void handleStartCommand(Long chatId) {
+        var welcomeText = "Добро пожаловать в Sense Game!\n"
+                + "Команды:\n"
+                + "/newgame - начать новую игру (можно указать параметры, например: /newgame categories=Флирт,Эксперимент difficulty=1-3)\n"
+                + "/nextcard - получить карточку для текущего игрока\n"
+                + "/skipcard - пропустить карточку и получить новую\n"
+                + "/stopgame - завершить текущую игру\n"
+                + "Используйте /help, чтобы посмотреть подробное описание команд.";
+        sendTextMessage(chatId, welcomeText);
+    }
+
+    private void handleHelpCommand(Long chatId) {
+        var helpText = "Доступные команды:\n"
+                + "/start - приветствие и краткие правила\n"
+                + "/newgame [categories=..] [difficulty=min-max] - начать новую игру с нужными фильтрами\n"
+                + "/nextcard - получить следующую карточку\n"
+                + "/skipcard - пропустить текущую карточку\n"
+                + "/stopgame - завершить игру и очистить состояние.";
+        sendTextMessage(chatId, helpText);
+    }
+
+    private void handleNewGameCommand(Long chatId, String message) {
+        var settings = parseSettings(message);
+        var session = gameSessionService.startSession(chatId, settings.categories(), settings.minDifficulty(), settings.maxDifficulty());
+        var response = new StringBuilder("Новая игра началась! Используйте /nextcard для получения карточки.\n");
+        response.append(session.describeSettings());
+        sendTextMessage(chatId, response.toString());
+    }
+
+    private void handleNextCardCommand(Update update, Long chatId) {
+        var sessionOptional = ensureActiveSession(chatId);
+        if (sessionOptional.isEmpty()) {
+            return;
+        }
+        var session = sessionOptional.get();
+        var card = cardService.getRandomCard(session.getCategories(), session.getMinDifficulty(), session.getMaxDifficulty(), session.getCurrentCard());
+        if (card.getId() != null && card.getId() == -1L) {
+            sendTextMessage(chatId, card.getText());
+            return;
+        }
+
+        var from = update.getMessage().getFrom();
+        var playerName = formatPlayerName(from.getFirstName(), from.getLastName(), from.getUserName());
+        gameSessionService.updateCurrentTurn(chatId, card, from.getId(), playerName);
+
+        var response = new StringBuilder();
+        response.append("Игрок ").append(playerName).append(", ваша карточка:\n");
+        response.append(card.getText());
+        response.append("\nКатегория: ").append(card.getCategory());
+        response.append("\nСложность: ").append(card.getDifficulty());
+        sendTextMessage(chatId, response.toString());
+    }
+
+    private void handleSkipCardCommand(Long chatId) {
+        var sessionOptional = ensureActiveSession(chatId);
+        if (sessionOptional.isEmpty()) {
+            return;
+        }
+        var session = sessionOptional.get();
+        var card = cardService.getRandomCard(session.getCategories(), session.getMinDifficulty(), session.getMaxDifficulty(), session.getCurrentCard());
+        if (card.getId() != null && card.getId() == -1L) {
+            sendTextMessage(chatId, card.getText());
+            return;
+        }
+
+        gameSessionService.updateCurrentCard(chatId, card);
+        var playerName = Optional.ofNullable(session.getCurrentPlayerName()).orElse("Игрок");
+
+        var response = new StringBuilder();
+        response.append("Карточка пропущена. ").append(playerName).append(", попробуйте новую:\n");
+        response.append(card.getText());
+        response.append("\nКатегория: ").append(card.getCategory());
+        response.append("\nСложность: ").append(card.getDifficulty());
+        sendTextMessage(chatId, response.toString());
+    }
+
+    private void handleStopGameCommand(Long chatId) {
+        if (!gameSessionService.isSessionActive(chatId)) {
+            sendTextMessage(chatId, "Активная игра не найдена. Используйте /newgame, чтобы начать новую сессию.");
+            return;
+        }
+        var session = gameSessionService.getSession(chatId).orElse(null);
+        gameSessionService.endSession(chatId);
+        var response = new StringBuilder("Игра завершена.");
+        if (session != null && session.getCurrentPlayerName() != null) {
+            response.append(" Последним ходил: ").append(session.getCurrentPlayerName()).append('.');
+        }
+        sendTextMessage(chatId, response.toString());
+    }
+
+    private Optional<GameSession> ensureActiveSession(Long chatId) {
+        var sessionOptional = gameSessionService.getSession(chatId);
+        if (sessionOptional.isEmpty() || !sessionOptional.get().isActive()) {
+            sendTextMessage(chatId, "Игра ещё не запущена. Используйте /newgame, чтобы начать новую сессию.");
+            return Optional.empty();
+        }
+        return sessionOptional;
+    }
+
+    private SessionSettings parseSettings(String message) {
+        var categories = new HashSet<String>();
+        Integer minDifficulty = null;
+        Integer maxDifficulty = null;
+
+        var parts = message.split("\\s+");
+        for (int i = 1; i < parts.length; i++) {
+            var part = parts[i];
+            var delimiterIndex = part.indexOf('=');
+            if (delimiterIndex <= 0) {
+                continue;
+            }
+            var key = part.substring(0, delimiterIndex).toLowerCase(Locale.ROOT);
+            var value = part.substring(delimiterIndex + 1).trim();
+            if (value.isEmpty()) {
+                continue;
+            }
+            switch (key) {
+                case "category", "categories" -> categories.addAll(parseCategories(value));
+                case "difficulty" -> {
+                    var range = parseDifficultyRange(value);
+                    minDifficulty = range.minDifficulty();
+                    maxDifficulty = range.maxDifficulty();
+                }
+                case "mindifficulty" -> minDifficulty = parseNumber(value).orElse(minDifficulty);
+                case "maxdifficulty" -> maxDifficulty = parseNumber(value).orElse(maxDifficulty);
+                default -> log.warn("Unknown parameter [{}] in /newgame command", key);
+            }
+        }
+        return new SessionSettings(categories, minDifficulty, maxDifficulty);
+    }
+
+    private Set<String> parseCategories(String value) {
+        var result = new HashSet<String>();
+        for (var category : value.split(",")) {
+            var trimmed = category.trim();
+            if (!trimmed.isEmpty()) {
+                result.add(trimmed);
+            }
+        }
+        return result;
+    }
+
+    private DifficultyRange parseDifficultyRange(String value) {
+        if (value.contains("-")) {
+            var rangeValues = value.split("-");
+            if (rangeValues.length == 2) {
+                var min = parseNumber(rangeValues[0]).orElse(null);
+                var max = parseNumber(rangeValues[1]).orElse(null);
+                return new DifficultyRange(min, max);
+            }
+        }
+        var number = parseNumber(value).orElse(null);
+        return new DifficultyRange(number, number);
+    }
+
+    private Optional<Integer> parseNumber(String value) {
+        try {
+            return Optional.of(Integer.parseInt(value));
+        } catch (NumberFormatException e) {
+            log.warn("Failed to parse number from value [{}]", value, e);
+            return Optional.empty();
+        }
+    }
+
+    private String extractCommand(String message) {
+        var spaceIndex = message.indexOf(' ');
+        return spaceIndex > 0 ? message.substring(0, spaceIndex).toLowerCase(Locale.ROOT) : message.toLowerCase(Locale.ROOT);
+    }
+
+    private String formatPlayerName(String firstName, String lastName, String username) {
+        var builder = new StringBuilder();
+        if (firstName != null && !firstName.isBlank()) {
+            builder.append(firstName.trim());
+        }
+        if (lastName != null && !lastName.isBlank()) {
+            if (builder.length() > 0) {
+                builder.append(' ');
+            }
+            builder.append(lastName.trim());
+        }
+        if (builder.length() == 0) {
+            if (username != null && !username.isBlank()) {
+                builder.append('@').append(username.trim());
+            } else {
+                builder.append("Игрок");
+            }
+        }
+        return builder.toString();
+    }
+
+    private record SessionSettings(Set<String> categories, Integer minDifficulty, Integer maxDifficulty) {}
+
+    private record DifficultyRange(Integer minDifficulty, Integer maxDifficulty) {}
 }
+


### PR DESCRIPTION
## Summary
- add an in-memory game session model and service to persist chat settings and the current turn
- extend the card service with category and difficulty filters and fallback handling
- implement Telegram bot commands for starting games, requesting and skipping cards, and ending sessions

## Testing
- mvn -q test

------
https://chatgpt.com/codex/tasks/task_b_68e14efea00c832885573d644c752b57